### PR TITLE
IP address loading takes much longer than it should

### DIFF
--- a/backend/libraries/scheduler/scheduler.go
+++ b/backend/libraries/scheduler/scheduler.go
@@ -1,8 +1,9 @@
 package scheduler
 
 import (
+	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -86,12 +87,13 @@ func ProvisionOnce(
 			return err
 		}
 
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		var bodyBuffer bytes.Buffer
+		_, err = io.Copy(&bodyBuffer, resp.Body)
 		if err != nil {
 			return err
 		}
 
-		loadedSets[name] = getIPsFromText(string(bodyBytes))
+		loadedSets[name] = getIPsFromText(bodyBuffer.String())
 	}
 	fmt.Printf("Loaded set queries: %d ms\n", time.Now().Sub(t0).Milliseconds())
 

--- a/backend/libraries/scheduler/scheduler.go
+++ b/backend/libraries/scheduler/scheduler.go
@@ -1,9 +1,8 @@
 package scheduler
 
 import (
-	"bytes"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -87,13 +86,12 @@ func ProvisionOnce(
 			return err
 		}
 
-		var bodyBuffer bytes.Buffer
-		_, err = io.Copy(&bodyBuffer, resp.Body)
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
 
-		loadedSets[name] = getIPsFromText(bodyBuffer.String())
+		loadedSets[name] = getIPsFromText(string(bodyBytes))
 	}
 	fmt.Printf("Loaded set queries: %d ms\n", time.Now().Sub(t0).Milliseconds())
 

--- a/backend/libraries/scheduler/scheduler.go
+++ b/backend/libraries/scheduler/scheduler.go
@@ -119,7 +119,7 @@ func Refresh(s *state.State) {
 func getIPsFromText(text string) []string {
 
 	textLines := strings.Split(text, "\n")
-	results := make([]string, 0)
+	results := make([]string, 0, len(textLines))
 	for _, line := range textLines {
 		if len(line) > 0 && string(line[0]) == "#" {
 			continue


### PR DESCRIPTION
### Code Description
- Added a capacity to the results slice in getIPsFromText to avoid reallocations
- io.Copy avoids unnecessary memory allocations and provides better performance when dealing with large response bodies