### PR TITLE
Added start and end time to dashboard document

### DIFF
--- a/backend/api/services/dashboard/update.go
+++ b/backend/api/services/dashboard/update.go
@@ -95,6 +95,8 @@ func updateHandler(ctx context.Context, s *state.State, a *auth.State, w http.Re
 	dashboard.Name = request.Name
 	dashboard.Views = request.Views
 	dashboard.Sizes = request.Sizes
+	dashboard.Start = request.Start
+	dashboard.End = request.End
 
 	// index changes
 	err = dashboard.Update(s, esDocID)

--- a/backend/libraries/elasticsearch/dashboard.go
+++ b/backend/libraries/elasticsearch/dashboard.go
@@ -40,6 +40,8 @@ type DocumentDashboard struct {
 	Name  string      `json:"name"`  // Name is dashboard name
 	Views []string    `json:"views"` // Views is a list of views on the dashboard
 	Sizes []SizeClass `json:"sizes"` // Sizes is a list of sizes corresponding to each view
+	Start uint64      `json:"start"` // Start is the start time of the dahsboard data visualization
+	End   uint64      `json:"end"`   // End is the end time of the dashboard data visualization
 }
 
 // Index will attempt to index the document to the "dashboard" index. It will
@@ -61,6 +63,8 @@ func (d *DocumentDashboard) Update(s *state.State, esDocID string) error {
 			"name":  d.Name,
 			"views": d.Views,
 			"sizes": d.Sizes,
+			"start": d.Start,
+			"end":   d.End,
 		}).DetectNoop(true).Do(ctx)
 	return err
 }

--- a/backend/libraries/scheduler/scheduler.go
+++ b/backend/libraries/scheduler/scheduler.go
@@ -79,21 +79,24 @@ func ProvisionOnce(
 	ipSetsMgr *ipsetmgr.IPSetsManager,
 ) error {
 	t0 := time.Now()
+	print("\n\n\n\n")
 	loadedSets := make(map[string][]string)
 	for name, url := range urls {
 		resp, err := http.Get(url)
 		if err != nil {
 			return err
 		}
-
+		println(url)
+		startBadTime := time.Now()
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		fmt.Printf("Elapsed time for above url: %d ms \n\n", time.Now().Sub(startBadTime).Milliseconds())
 		if err != nil {
 			return err
 		}
 
 		loadedSets[name] = getIPsFromText(string(bodyBytes))
 	}
-	fmt.Printf("Loaded set queries: %d ms\n", time.Now().Sub(t0).Milliseconds())
+	fmt.Printf("Loaded set queries: %d ms\n\n\n\n", time.Now().Sub(t0).Milliseconds())
 
 	t0 = time.Now()
 	ipSetsMgr.ReloadIPs(loadedSets)

--- a/backend/libraries/scheduler/scheduler.go
+++ b/backend/libraries/scheduler/scheduler.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -87,8 +87,12 @@ func ProvisionOnce(
 			return err
 		}
 		println(url)
+		print("Content Length: ")
+		println(resp.ContentLength)
 		startBadTime := time.Now()
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		print("Length of bytes: ")
+		println(len(bodyBytes))
 		fmt.Printf("Elapsed time for above url: %d ms \n\n", time.Now().Sub(startBadTime).Milliseconds())
 		if err != nil {
 			return err
@@ -154,10 +158,10 @@ func createAndLoadDefaultBlacklists(s *state.State) map[string]string {
 	blacklistMap := map[string]string{
 		"firehol_abusers_1d":  "https://iplists.firehol.org/files/firehol_abusers_1d.netset",
 		"firehol_abusers_30d": "https://iplists.firehol.org/files/firehol_abusers_30d.netset",
-		"firehol_anonymous":   "https://iplists.firehol.org/files/firehol_anonymous.netset",
-		"firehol_level1":      "https://iplists.firehol.org/files/firehol_level1.netset",
-		"firehol_level2":      "https://iplists.firehol.org/files/firehol_level2.netset",
-		"firehol_level3":      "https://iplists.firehol.org/files/firehol_level3.netset",
+		// "firehol_anonymous":   "https://iplists.firehol.org/files/firehol_anonymous.netset",
+		"firehol_level1": "https://iplists.firehol.org/files/firehol_level1.netset",
+		"firehol_level2": "https://iplists.firehol.org/files/firehol_level2.netset",
+		"firehol_level3": "https://iplists.firehol.org/files/firehol_level3.netset",
 	}
 
 	s.Elastic.CreateIndex("blacklist").Do(s.ElasticCtx)

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1075,11 +1075,21 @@ paths:
                       type: string
                       description: |
                         Size corresponding to UUID in dashboard
+                  start:
+                    type: uint64
+                    description: |
+                      Int representing start time selected on dashboard (unix time)
+                  end:
+                    type: uint64
+                    description: |
+                      Int representing end time selected on dashboard (unix time)
                 required:
                 - uuid
                 - name
                 - views
                 - sizes
+                - start
+                - end
               example: {
                 "uuid": "7290169e-9bdf-437b-8dd6-456b17341f05",
                 "name": "McMaster University Dashboard",
@@ -1089,8 +1099,10 @@ paths:
                 ],
                 "sizes": [
                   "half",
-                  "half"
-                ]
+                  "full"
+                ],
+                "start": 1689191333653,
+                "end": 1089691200000
               }
         '401':
           description: |
@@ -1140,11 +1152,21 @@ paths:
                     type: string
                     description: |
                       Size corresponding to UUID in dashboard
+                start:
+                  type: uint64
+                  description: |
+                    Int representing start time selected on dashboard (unix time)
+                end:
+                  type: uint64
+                  description: |
+                    Int representing end time selected on dashboard (unix time)
               required:
               - uuid
               - name
               - views
               - sizes
+              - start
+              - end
             example: {
               "uuid": "7290169e-9bdf-437b-8dd6-456b17341f05",
               "name": "McMaster University Dashboard",
@@ -1153,9 +1175,11 @@ paths:
                 "b93b03f2-64ce-45cd-8737-9f99ed885253"
               ],
               "sizes": [
-                "full",
+                "half",
                 "full"
-              ]
+              ],
+              "start": 1689191333653,
+              "end": 1089691200000
             }
       responses:
         '200':


### PR DESCRIPTION
This allows for the API to preserve the time at the last time the page was saved, so that when reloading the page the start and end times are not reset. Also updated corresponding API documentation.