### PR TITLE
Alarm filtering by Source and Dest IP, Alarm Destination Lists

### DIFF
--- a/backend/api/services/alarm/data.go
+++ b/backend/api/services/alarm/data.go
@@ -19,13 +19,15 @@ import (
 )
 
 type dataRequest struct {
-	Index   []string `json:"index"`   // Index is the list of indices to search
-	Source  []string `json:"source"`  // Source is the list of sources to search
-	Dest    []string `json:"dest"`    // Dest is the list of destination alarms to search
-	Start   string   `json:"start"`   // Start is the start time of the search
-	End     string   `json:"end"`     // End is the end time of the search
-	MaxSize int      `json:"maxSize"` // MaxSize is the maximum number of documents to return
-	From    int      `json:"from"`    // From is the starting index of the search
+	Index    []string `json:"index"`    // Index is the list of indices to search
+	Source   []string `json:"source"`   // Source is the list of sources to search
+	Dest     []string `json:"dest"`     // Dest is the list of destination alarms to search
+	Start    string   `json:"start"`    // Start is the start time of the search
+	End      string   `json:"end"`      // End is the end time of the search
+	MaxSize  int      `json:"maxSize"`  // MaxSize is the maximum number of documents to return
+	From     int      `json:"from"`     // From is the starting index of the search
+	SourceIp string   `json:"sourceIp"` // SourceIp contains the beginning of a searched alarm source IP (alarms will be filtered by containing this string at the beginning of id_orig_h, leave empty to not filter by IP)
+	DestIp   string   `json:"destIp"`   // destIp contains the beginning of a searched alarm source IP (alarms will be filtered by containing this string at the beginning of id_resp_h, leave empty to not filter by IP)
 }
 
 type dataResponse struct {
@@ -35,7 +37,7 @@ type dataResponse struct {
 
 const maxCards = 20
 
-// dataHandler is "/api/data. It is responsible for populating a view with the data related to that view.
+// dataHandler is "/api/alarm/data. It is responsible for populating a view with the data related to that view.
 func dataHandler(ctx context.Context, s *state.State, a *auth.State, w http.ResponseWriter, r *http.Request) {
 	// get user making current request + logging context
 	_, l := jwtauth.FromContext(ctx), ctxlog.Log(ctx)
@@ -98,7 +100,7 @@ func dataHandler(ctx context.Context, s *state.State, a *auth.State, w http.Resp
 	}
 
 	// get data for the specified fields in the specified time range, sorted by timestamp
-	data, availableRows, err := elasticsearch.GetAlarms(s, request.Index, request.Source, request.Dest, start, end, request.MaxSize, request.From)
+	data, availableRows, err := elasticsearch.GetAlarms(s, request.Index, request.Source, request.Dest, start, end, request.MaxSize, request.From, request.SourceIp, request.DestIp)
 	if err != nil {
 		l.Error("error querying data conn: ", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/backend/api/services/alarm/data.go
+++ b/backend/api/services/alarm/data.go
@@ -21,6 +21,7 @@ import (
 type dataRequest struct {
 	Index   []string `json:"index"`   // Index is the list of indices to search
 	Source  []string `json:"source"`  // Source is the list of sources to search
+	Dest    []string `json:"dest"`    // Dest is the list of destination alarms to search
 	Start   string   `json:"start"`   // Start is the start time of the search
 	End     string   `json:"end"`     // End is the end time of the search
 	MaxSize int      `json:"maxSize"` // MaxSize is the maximum number of documents to return
@@ -97,7 +98,7 @@ func dataHandler(ctx context.Context, s *state.State, a *auth.State, w http.Resp
 	}
 
 	// get data for the specified fields in the specified time range, sorted by timestamp
-	data, availableRows, err := elasticsearch.GetAlarms(s, request.Index, request.Source, start, end, request.MaxSize, request.From)
+	data, availableRows, err := elasticsearch.GetAlarms(s, request.Index, request.Source, request.Dest, start, end, request.MaxSize, request.From)
 	if err != nil {
 		l.Error("error querying data conn: ", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1240,6 +1240,14 @@ paths:
                   type: integer
                   description: |
                     Search offset of alarms query
+                sourceIp:
+                  type: string
+                  description: |
+                    Prefix string of source IP (returned alarms will have source IP starting with string passed here. "" will not filter by sourceIP)
+                destIp:
+                  type: string
+                  description: |
+                    Prefix string of desitnation IP (returned alarms will have source IP starting with string passed here. "" will not filter by destIP)
               required:
                 - index
                 - source
@@ -1250,10 +1258,13 @@ paths:
             example: {
               "index": ["http.log.alarm", "dns.log.alarm"],
               "source": ["firehol_abusers_1d", "firehol_abusers_30d", "firehol_anonymous", "firehol_level2"],
+              "dest":  ["firehol_abusers_1d", "firehol_abusers_30d", "firehol_anonymous", "firehol_level2"],
               "start": "2019-05-01T12:41:55.000Z",
               "end": "2023-05-15T13:11:55.495Zd",
               "maxSize": 4,
               "from": 0
+              "sourceIp": "192.16"
+              "destIp": ""
             }
       responses:
         '200':

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -1215,7 +1215,13 @@ paths:
                 source:
                   type: array
                   description: |
-                    List of blacklists to pull alarms from
+                    List of source blacklists to pull alarms from
+                  items:
+                    type: string  
+                dest:
+                  type: array
+                  description: |
+                    List of destination blacklists to pull alarms from
                   items:
                     type: string  
                 start:


### PR DESCRIPTION
Added backend support for various filtering tasks and corresponding documentation in the Swagger file. [Jira issue](https://fyelabs.atlassian.net/jira/software/projects/CIDS/boards/2?selectedIssue=CIDS-47).

- Alarm destination list filtering works in the same way as alarm source list, taking in an array of strings representing the various destinations
- Source and destination IP each take a string, and return hits that have their associated source or destination IP beginning with the passed string (passing "192." would hit IPs that start with that string)