### PR TITLE
Setup API

### DIFF
--- a/backend/api/services/auth/register.go
+++ b/backend/api/services/auth/register.go
@@ -29,4 +29,8 @@ func RegisterRoutes(s *state.State, a *jwtauth.Config, r *mux.Router) {
 	r.HandleFunc("/registerUser", func(w http.ResponseWriter, r *http.Request) {
 		registerUserHandler(s, a, w, r)
 	})
+
+	r.HandleFunc("/setup", func(w http.ResponseWriter, r *http.Request) {
+		setupUserHandler(s, a, w, r)
+	})
 }

--- a/backend/api/services/auth/setup.go
+++ b/backend/api/services/auth/setup.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/mcmaster-circ/canids-v2/backend/auth"
+	"github.com/mcmaster-circ/canids-v2/backend/libraries/ctxlog"
+	"github.com/mcmaster-circ/canids-v2/backend/libraries/elasticsearch"
+	"github.com/mcmaster-circ/canids-v2/backend/libraries/jwtauth"
+	"github.com/mcmaster-circ/canids-v2/backend/state"
+)
+
+type SetupRequest struct {
+	Name            string `json:"name"`
+	UUID            string `json:"uuid"`
+	Password        string `json:"password"`
+	PasswordConfirm string `json:"passwordConfirm"`
+}
+
+func setupUserHandler(s *state.State, a *jwtauth.Config, w http.ResponseWriter, r *http.Request) {
+
+	l := ctxlog.Log(r.Context())
+	w.Header().Set("Content-Type", "application/json")
+
+	var request SetupRequest
+
+	// Decode request json
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		l.Error("[setup] unable to decode json")
+
+		w.WriteHeader(http.StatusBadRequest)
+		out := GeneralResponse{
+			Success: false,
+			Message: "Bad request format.",
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	// Validate all fields
+	if request.Name == "" || request.UUID == "" || request.Password == "" || request.PasswordConfirm == "" {
+		l.Info("[setup] not all fields specified")
+		w.WriteHeader(http.StatusBadRequest)
+		out := GeneralResponse{
+			Success: false,
+			Message: "All fields must be specified.",
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	// Ensure passwords are the same
+	if request.Password != request.PasswordConfirm {
+		l.Info("[setup] password and confirmation password are not equal")
+		w.WriteHeader(http.StatusBadRequest)
+		out := GeneralResponse{
+			Success: false,
+			Message: "Passwords must match.",
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	if !s.AuthReady {
+		w.WriteHeader(http.StatusInternalServerError)
+		out := GeneralResponse{
+			Success: false,
+			Message: "Authentication not ready",
+		}
+		json.NewEncoder(w).Encode(out)
+
+		return
+	}
+
+	// Check if email already in elasticsearch
+	_, _, err = elasticsearch.QueryAuthByUUID(s, request.UUID)
+	if err == nil {
+		l.Error("[setup] email already exists ", request.UUID)
+		w.WriteHeader(http.StatusBadRequest)
+		out := GeneralResponse{
+			Success: false,
+			Message: "Email already registered.",
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	// Hash and salt password
+	hashedPass, err := jwtauth.HashPassword(request.Password)
+	if err != nil {
+		l.Error("[setup] cannot hash password ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		out := GeneralResponse{
+			Success: false,
+			Message: "Please contact the system administrator.",
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	// Create user for elastic search
+	user := elasticsearch.DocumentAuth{
+		UUID:      request.UUID,
+		Name:      request.Name,
+		Password:  hashedPass,
+		Activated: true,
+		Class:     jwtauth.UserAdmin,
+	}
+
+	// Index in "auth"
+	_, err = user.Index(s)
+	if err != nil {
+		l.Error("[setup] cannot index user ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		out := GeneralResponse{
+			Success: false,
+			Message: "Please contact the system administrator.",
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	payload := &jwtauth.Payload{
+		UUID:      request.UUID,
+		Name:      request.Name,
+		Activated: true,
+		Class:     jwtauth.UserAdmin,
+	}
+
+	payload.IssuedAt = time.Now().Unix()
+	token, err := a.CreateToken(payload, auth.ExpireAge)
+	if err != nil {
+		// can't issue new token, return login page with error
+		l.Error("[setup] failed to create authentication token ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		out := GeneralResponse{
+			Success: false,
+			Message: "Please contact the system administrator.",
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	// generate new X-State cookie, send to browser
+	cookie := http.Cookie{
+		Name:     "X-State",
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true, // secure the cookie from JS attacks
+	}
+	// upgrade cookie security if site is accessible over SSL
+	if s.Config.HTTPSEnabled {
+		cookie.SameSite = http.SameSiteStrictMode
+		cookie.Secure = true
+	}
+	http.SetCookie(w, &cookie)
+
+	// generate new X-Class cookie, send to browser
+	cookie = http.Cookie{
+		Name:     "X-Class",
+		Value:    string(user.Class),
+		Path:     "/",
+		HttpOnly: true, // secure the cookie from JS attacks
+	}
+	// upgrade cookie security if site is accessible over SSL
+	if s.Config.HTTPSEnabled {
+		cookie.SameSite = http.SameSiteStrictMode
+		cookie.Secure = true
+	}
+	http.SetCookie(w, &cookie)
+
+	l.Info("[login] token issued, X-State and X-Class cookies set")
+	w.WriteHeader(http.StatusOK)
+	out := GeneralResponse{
+		Success: true,
+		Message: "Successfully created your account and logged in",
+	}
+	json.NewEncoder(w).Encode(out)
+
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -42,9 +42,6 @@ func main() {
 		s.Log.Fatal(err)
 	}
 
-	//Create default user
-	auth.DefaultUserSetup(s, a)
-
 	p := auth.ProvisionAuthPage(s)
 
 	// start API server

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -283,6 +283,45 @@ paths:
                 "uptime": "1h5m31.570680928s"
               }
   
+  /auth/setup:
+    post:
+      summary: User setup endpoint
+      description: |
+        Takes email, password, and name to create new user, setting cookies to log them in at the same time
+      tags:
+      - Primary
+      requestBody:
+        required: true
+        content:
+          type: json object
+          properties:
+            Name:
+              type: string
+              description: |
+                The name of the prospective user
+            UUID:
+              type: string
+              description: |
+                The email address of the prospective user
+            Password:
+              type: string
+              description: |
+                The desired password of the prospective user
+            PasswordConfirm:
+              type: string
+              description: |
+                The re-entered password of the prospective user
+      responses:
+        '200':
+          description: |
+            Successfully created user, logged in
+        '400':
+          description: |
+            Unable to decode json, not all fields provided, email already exists in db, passwords are not equal
+        '500':
+          description: |
+            Error hashing password or inserting user into database, failed to create token for login
+
   /auth/login:
     post:
       summary: Login endpoint


### PR DESCRIPTION
Added setup API that takes in name, email, password and confirm password to create a user, and log the user in by setting jwt auth cookies. Removed default user creation.